### PR TITLE
Simple component-exists check to avoid throwing exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.4.1
+- Fix potential error if component is destroyed before it has a chance to render.
+
 ## 0.4.0
 - Switch to more friendly prop syntax for `{{> SvelteComponent}}`
 - Allow directly passing component as only arg to `{{> SvelteComponent}}`

--- a/SvelteComponent.js
+++ b/SvelteComponent.js
@@ -61,7 +61,7 @@ Template.SvelteComponent.onRendered(function onRendered() {
 });
 
 Template.SvelteComponent.onDestroyed(function onDestroyed() {
-  this.component.$destroy();
+  if (this.component) this.component.$destroy();
 });
 
 function create_default_slot(ctx) {

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   name: 'svelte:blaze-integration',
-  version: '0.4.0',
+  version: '0.4.1',
   summary: 'Render Blaze templates inside your Svelte components and vice versa.',
   git: 'https://github.com/meteor-svelte/blaze-integration',
   documentation: 'README.md',


### PR DESCRIPTION
My Svelte-in-Blaze app was sometimes throwing errors in this part of `SvelteComponent.js`:

```js
Template.SvelteComponent.onDestroyed(function onDestroyed() {
  this.component.$destroy();
});
```

My guess is that the template was getting destroyed before it had a chance to be rendered. I don't know why, but adding a check to see if `this.component` exists before calling `.$destroy()` seemed like an easy and pragmatic solution. Seems to be working well now with no side effects that I can detect.